### PR TITLE
Fix ingestion URL

### DIFF
--- a/ingest.py
+++ b/ingest.py
@@ -9,7 +9,7 @@ from langchain.vectorstores.faiss import FAISS
 
 def ingest_docs():
     """Get documents from web pages."""
-    loader = ReadTheDocsLoader("langchain.readthedocs.io/en/latest/")
+    loader = ReadTheDocsLoader("python.langchain.com/en/latest/")
     raw_documents = loader.load()
     text_splitter = RecursiveCharacterTextSplitter(
         chunk_size=1000,

--- a/ingest.sh
+++ b/ingest.sh
@@ -2,5 +2,5 @@
 # This involves scraping the data from the web and then cleaning up and putting in Weaviate.
 # Error if any command fails
 set -e
-wget -r -A.html https://langchain.readthedocs.io/en/latest/
+wget -r -A.html https://python.langchain.com/en/latest/
 python3 ingest.py


### PR DESCRIPTION
## Background

The ingestion process (wget specifically) isn't downloading the ReadTheDocs content anymore because the URL changed. It grabs the index page, and there is no error, so it's not obvious that it's not working. The result is just poor results with the chat bot.

## Changes

- Updated the URL for scraping Read The Docs with wget
- Updated the ReadTheDocsLoader path to point to new scraped folder path.


Thanks!