### PR TITLE
specify Python version below 3.12

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ authors = ["SN <6432132+samnoyes@users.noreply.github.com>"]
 readme = "README.md"
 
 [tool.poetry.dependencies]
-python = "^3.10"
+python = ">=3.10,<=3.11"
 fastapi = "^0.103.1"
 pydantic = "1.10"
 langchain = { git = "https://github.com/langchain-ai/langchain.git", subdirectory = "libs/langchain" }


### PR DESCRIPTION
I noticed that this project is using numpy 1.25.2.

According to [https://numpy.org/doc/stable/release/1.26.0-notes.html](numpy release note), numpy 1.25.2 isn't compatible with Python 3.12, so we should specify a Python version below 3.12.
