### PR TITLE
fix token duplication in frontend

### DIFF
--- a/frontend/app/components/ChatWindow.tsx
+++ b/frontend/app/components/ChatWindow.tsx
@@ -132,7 +132,7 @@ export function ChatWindow(props: { conversationId: string }) {
         },
       );
       for await (const chunk of streamLog) {
-        streamedResponse = applyPatch(streamedResponse, chunk.ops).newDocument;
+        streamedResponse = applyPatch(streamedResponse, chunk.ops, undefined, false).newDocument;
         if (
           Array.isArray(
             streamedResponse?.logs?.[sourceStepName]?.final_output?.output,


### PR DESCRIPTION
applyPatch modifies the document so every token got added twice to the stream

Fixes: #300 