### PR TITLE
Update ChatWindow.tsx

### DIFF
--- a/frontend/app/components/ChatWindow.tsx
+++ b/frontend/app/components/ChatWindow.tsx
@@ -253,6 +253,10 @@ export function ChatWindow(props: { conversationId: string }) {
                   setLlm(e.target.value);
                 }}
                 width={"240px"}
+                style={{
+                  backgroundColor: "#131318", 
+                  color: "#f8f8f8",
+                }}
               >
                 <option value="openai_gpt_3_5_turbo">GPT-3.5-Turbo</option>
                 <option value="anthropic_claude_3_sonnet">Claude 3 Sonnet</option>


### PR DESCRIPTION
The selection dropdown menu for powered by has a white background with white text so options arent visible until hovered over. This change fixes that and sets the background of the dropdown to black so the options are visible.