### PR TITLE
fix: access query value in output for online evals

### DIFF
--- a/backend/retrieval_graph/graph.py
+++ b/backend/retrieval_graph/graph.py
@@ -145,7 +145,11 @@ async def create_research_plan(
         {"role": "system", "content": configuration.research_plan_system_prompt}
     ] + state.messages
     response = cast(Plan, await model.ainvoke(messages))
-    return {"steps": response["steps"], "documents": "delete", "query": state.messages[-1].content}
+    return {
+        "steps": response["steps"],
+        "documents": "delete",
+        "query": state.messages[-1].content,
+    }
 
 
 async def conduct_research(state: AgentState) -> dict[str, Any]:

--- a/backend/retrieval_graph/graph.py
+++ b/backend/retrieval_graph/graph.py
@@ -145,7 +145,7 @@ async def create_research_plan(
         {"role": "system", "content": configuration.research_plan_system_prompt}
     ] + state.messages
     response = cast(Plan, await model.ainvoke(messages))
-    return {"steps": response["steps"], "documents": "delete"}
+    return {"steps": response["steps"], "documents": "delete", "query": state.messages[-1].content}
 
 
 async def conduct_research(state: AgentState) -> dict[str, Any]:

--- a/backend/retrieval_graph/state.py
+++ b/backend/retrieval_graph/state.py
@@ -81,3 +81,4 @@ class AgentState(InputState):
     """Populated by the retriever. This is a list of documents that the agent can reference."""
     answer: str = field(default="")
     """Final answer. Useful for evaluations"""
+    query: str = field(default="")


### PR DESCRIPTION
store query value in output so automation rules can access it to perform LLM judge evaluation