### PR TITLE
Update ingest to pull from the new docs site

### DIFF
--- a/backend/ingest.py
+++ b/backend/ingest.py
@@ -13,12 +13,16 @@ from langchain.utils.html import PREFIXES_TO_IGNORE_REGEX, SUFFIXES_TO_IGNORE_RE
 from langchain_text_splitters import RecursiveCharacterTextSplitter
 from langchain_weaviate import WeaviateVectorStore
 
-from backend.constants import WEAVIATE_DOCS_INDEX_NAME
+from backend.constants import WEAVIATE_GENERAL_GUIDES_AND_TUTORIALS_INDEX_NAME
 from backend.embeddings import get_embeddings_model
 from backend.parser import langchain_docs_extractor
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
+
+WEAVIATE_URL = os.environ["WEAVIATE_URL"]
+WEAVIATE_API_KEY = os.environ["WEAVIATE_API_KEY"]
+RECORD_MANAGER_DB_URL = os.environ["RECORD_MANAGER_DB_URL"]
 
 
 def metadata_extractor(
@@ -42,7 +46,25 @@ def metadata_extractor(
     }
 
 
-def load_langchain_docs():
+def simple_extractor(html: str | BeautifulSoup) -> str:
+    if isinstance(html, str):
+        soup = BeautifulSoup(html, "lxml")
+    elif isinstance(html, BeautifulSoup):
+        soup = html
+    else:
+        raise ValueError(
+            "Input should be either BeautifulSoup object or an HTML string"
+        )
+    return re.sub(r"\n\n+", "\n\n", soup.text).strip()
+
+
+#########################
+# General Guides and Tutorials
+#########################
+
+
+# NOTE: To be deprecated once LangChain docs are migrated to new site.
+def load_langchain_python_docs():
     return SitemapLoader(
         "https://python.langchain.com/sitemap.xml",
         filter_urls=["https://python.langchain.com/"],
@@ -57,73 +79,44 @@ def load_langchain_docs():
     ).load()
 
 
-def load_langgraph_docs():
+# NOTE: To be deprecated once LangChain docs are migrated to new site.
+def load_langchain_js_docs():
     return SitemapLoader(
-        "https://langchain-ai.github.io/langgraph/sitemap.xml",
+        "https://js.langchain.com/sitemap.xml",
         parsing_function=simple_extractor,
         default_parser="lxml",
-        bs_kwargs={"parse_only": SoupStrainer(name=("article", "title"))},
-        meta_function=lambda meta, soup: metadata_extractor(
-            meta, soup, title_suffix=" | 🦜🕸️LangGraph"
-        ),
+        bs_kwargs={
+            "parse_only": SoupStrainer(
+                name=("article", "title", "html", "lang", "content")
+            )
+        },
+        meta_function=metadata_extractor,
+        filter_urls=["https://js.langchain.com/docs/"],
     ).load()
 
 
-def load_langsmith_docs():
-    return RecursiveUrlLoader(
-        url="https://docs.smith.langchain.com/",
-        max_depth=8,
-        extractor=simple_extractor,
-        prevent_outside=True,
-        use_async=True,
-        timeout=600,
-        # Drop trailing / to avoid duplicate pages.
-        link_regex=(
-            f"href=[\"']{PREFIXES_TO_IGNORE_REGEX}((?:{SUFFIXES_TO_IGNORE_REGEX}.)*?)"
-            r"(?:[\#'\"]|\/[\#'\"])"
-        ),
-        check_response_status=True,
+def load_aggregated_docs_site():
+    return SitemapLoader(
+        "https://docs.langchain.com/sitemap.xml",
+        parsing_function=simple_extractor,
+        default_parser="lxml",
+        bs_kwargs={
+            "parse_only": SoupStrainer(
+                name=("article", "title", "html", "lang", "content")
+            )
+        },
+        meta_function=metadata_extractor,
     ).load()
 
 
-def simple_extractor(html: str | BeautifulSoup) -> str:
-    if isinstance(html, str):
-        soup = BeautifulSoup(html, "lxml")
-    elif isinstance(html, BeautifulSoup):
-        soup = html
-    else:
-        raise ValueError(
-            "Input should be either BeautifulSoup object or an HTML string"
-        )
-    return re.sub(r"\n\n+", "\n\n", soup.text).strip()
-
-
-def load_api_docs():
-    return RecursiveUrlLoader(
-        url="https://api.python.langchain.com/en/latest/",
-        max_depth=8,
-        extractor=simple_extractor,
-        prevent_outside=True,
-        use_async=True,
-        timeout=600,
-        # Drop trailing / to avoid duplicate pages.
-        link_regex=(
-            f"href=[\"']{PREFIXES_TO_IGNORE_REGEX}((?:{SUFFIXES_TO_IGNORE_REGEX}.)*?)"
-            r"(?:[\#'\"]|\/[\#'\"])"
-        ),
-        check_response_status=True,
-        exclude_dirs=(
-            "https://api.python.langchain.com/en/latest/_sources",
-            "https://api.python.langchain.com/en/latest/_modules",
-        ),
-    ).load()
+def ingest_general_guides_and_tutorials():
+    langchain_python_docs = load_langchain_python_docs()
+    langchain_js_docs = load_langchain_js_docs()
+    aggregated_site_docs = load_aggregated_docs_site()
+    return langchain_python_docs + langchain_js_docs + aggregated_site_docs
 
 
 def ingest_docs():
-    WEAVIATE_URL = os.environ["WEAVIATE_URL"]
-    WEAVIATE_API_KEY = os.environ["WEAVIATE_API_KEY"]
-    RECORD_MANAGER_DB_URL = os.environ["RECORD_MANAGER_DB_URL"]
-
     text_splitter = RecursiveCharacterTextSplitter(chunk_size=4000, chunk_overlap=200)
     embedding = get_embeddings_model()
 
@@ -132,33 +125,22 @@ def ingest_docs():
         auth_credentials=weaviate.classes.init.Auth.api_key(WEAVIATE_API_KEY),
         skip_init_checks=True,
     ) as weaviate_client:
-        vectorstore = WeaviateVectorStore(
+        # General Guides and Tutorials
+        general_guides_and_tutorials_vectorstore = WeaviateVectorStore(
             client=weaviate_client,
-            index_name=WEAVIATE_DOCS_INDEX_NAME,
+            index_name=WEAVIATE_GENERAL_GUIDES_AND_TUTORIALS_INDEX_NAME,
             text_key="text",
             embedding=embedding,
             attributes=["source", "title"],
         )
-
         record_manager = SQLRecordManager(
-            f"weaviate/{WEAVIATE_DOCS_INDEX_NAME}", db_url=RECORD_MANAGER_DB_URL
+            f"weaviate/{WEAVIATE_GENERAL_GUIDES_AND_TUTORIALS_INDEX_NAME}",
+            db_url=RECORD_MANAGER_DB_URL,
         )
         record_manager.create_schema()
-
-        docs_from_documentation = load_langchain_docs()
-        logger.info(f"Loaded {len(docs_from_documentation)} docs from documentation")
-        docs_from_api = load_api_docs()
-        logger.info(f"Loaded {len(docs_from_api)} docs from API")
-        docs_from_langsmith = load_langsmith_docs()
-        logger.info(f"Loaded {len(docs_from_langsmith)} docs from LangSmith")
-        docs_from_langgraph = load_langgraph_docs()
-        logger.info(f"Loaded {len(docs_from_langgraph)} docs from LangGraph")
-
+        general_guides_and_tutorials_docs = ingest_general_guides_and_tutorials()
         docs_transformed = text_splitter.split_documents(
-            docs_from_documentation
-            + docs_from_api
-            + docs_from_langsmith
-            + docs_from_langgraph
+            general_guides_and_tutorials_docs
         )
         docs_transformed = [
             doc for doc in docs_transformed if len(doc.page_content) > 10
@@ -172,24 +154,24 @@ def ingest_docs():
                 doc.metadata["source"] = ""
             if "title" not in doc.metadata:
                 doc.metadata["title"] = ""
-
         indexing_stats = index(
             docs_transformed,
             record_manager,
-            vectorstore,
+            general_guides_and_tutorials_vectorstore,
             cleanup="full",
             source_id_key="source",
             force_update=(os.environ.get("FORCE_UPDATE") or "false").lower() == "true",
         )
-
         logger.info(f"Indexing stats: {indexing_stats}")
         num_vecs = (
-            weaviate_client.collections.get(WEAVIATE_DOCS_INDEX_NAME)
+            weaviate_client.collections.get(
+                WEAVIATE_GENERAL_GUIDES_AND_TUTORIALS_INDEX_NAME
+            )
             .aggregate.over_all()
             .total_count
         )
         logger.info(
-            f"LangChain now has this many vectors: {num_vecs}",
+            f"General Guides and Tutorials now has this many vectors: {num_vecs}",
         )
 
 


### PR DESCRIPTION
- We still pull LangChain Python and JS docs directly. These will become unnecessary and can be removed when they are added to the main docs site
- We no longer index API docs, these will be handled separately