### PR TITLE
fix(docs_tools): filter stale URLs in search results using existing validator

### DIFF
--- a/src/tools/docs_tools.py
+++ b/src/tools/docs_tools.py
@@ -7,6 +7,8 @@ import logging
 import os
 import time
 from typing import Any
+import asyncio
+from src.tools.link_check_tools import _check_urls_async
 
 import requests
 from langchain.tools import tool
@@ -230,6 +232,12 @@ def _format_search_results(results: list[dict[str, Any]]) -> str:
             f"Link: {url}\n"
             f"Content: {content}\n"
         )
+        # Filter stale URLs using existing validator (was never called in this pipeline)
+    if urls:
+        check_results = asyncio.run(_check_urls_async(urls, timeout=5.0))
+        valid_urls = {r.url for r in check_results if r.valid}
+        urls = [u for u in urls if u in valid_urls]
+        formatted = [f for f in formatted if any(u in f for u in valid_urls)]
 
     _track_docs_for_langsmith(urls)
     return "\n---\n\n".join(formatted)


### PR DESCRIPTION
## Problem
`_format_search_results()` constructs URLs from Mintlify API paths and 
returns them immediately with no validation. Stale paths (e.g. from 
Mintlify's index being out of sync) produce broken URLs that reach the 
agent and get recorded in LangSmith traces.

`_check_urls_async()` in `link_check_tools.py` was purpose-built for 
this -it even has soft-404 detection specifically for `docs.langchain.com` 
-but was never called anywhere in the search pipeline.

## Fix
Wire `_check_urls_async()` into `_format_search_results()` to filter 
invalid URLs before they're returned.

## Complementary to existing work
- #530 -prompt-level ban on stale domains (catches LLM hallucinations)  
- #531 -domain blocklist in check_links (catches deprecated redirects)  

This addresses a separate vector: broken URLs originating from the 
search tool's own API results.