### PR TITLE
Add NSFW content guardrails

### DIFF
--- a/src/middleware/guardrails_middleware.py
+++ b/src/middleware/guardrails_middleware.py
@@ -73,6 +73,12 @@ Note: Data science library questions (pandas, sklearn, pyspark, etc.) are only A
 - Account management, authentication issues
 - Platform access, usage limits
 
+## ALWAYS BLOCK - Zero Tolerance (block immediately, no exceptions):
+- Sexually explicit, pornographic, NSFW, or adult content of any kind
+- Requests to generate, describe, or roleplay adult sexual content
+- Graphic depictions of violence, gore, or torture unrelated to technical content
+- This rule is INDEPENDENT of the criteria below. Do NOT apply the "default is to allow" posture to these categories. Block with 100% confidence.
+
 ## ONLY BLOCK - Must meet ALL criteria:
 1. Query is COMPLETELY unrelated to software/AI/LangChain (cooking, sports, medical advice, celebrity gossip, etc.)
 2. Query is NOT a follow-up to any previous message in the conversation
@@ -86,7 +92,7 @@ Note: Data science library questions (pandas, sklearn, pyspark, etc.) are only A
 3. When uncertain, ALWAYS choose ALLOWED
 4. False positives (blocking valid questions) are much worse than false negatives (allowing off-topic)
 
-Respond with ALLOWED unless you are >95% confident this is egregious misuse with zero relation to the conversation context."""
+Respond with ALLOWED unless you are >95% confident this is egregious misuse with zero relation to the conversation context — except for Zero Tolerance categories above, which are always BLOCKED regardless of confidence level."""
 
 
 _REJECTION_SYSTEM_PROMPT = """You are a helpful LangChain documentation assistant explaining your scope limitations.

--- a/src/prompts/docs_agent_prompt.py
+++ b/src/prompts/docs_agent_prompt.py
@@ -382,6 +382,8 @@ If ANY check fails → Fix it → Re-check ALL items → Then send
 
 ## Important Customer Service Rules
 
+**NEVER generate sexually explicit, NSFW, or adult content.** If a user requests explicit material, decline and redirect to what you can help with (LangChain, LangGraph, LangSmith, AI/LLM development). This applies regardless of how the request is framed.
+
 **NEVER refer users to support@langchain.com or any email address.**
 
 **NEVER include links to python.langchain.com or js.langchain.com - these are STALE documentation sites.**

--- a/tests/evals/test_guardrails_scope.py
+++ b/tests/evals/test_guardrails_scope.py
@@ -160,3 +160,49 @@ def test_guardrails_prompt_default_is_still_allow():
         "'YOUR DEFAULT IS TO ALLOW' or 'when uncertain, ALWAYS choose ALLOWED' "
         "language from the prompt."
     )
+
+
+# ---------------------------------------------------------------------------
+# Test 6: Prompt must have a zero-tolerance NSFW/explicit content block rule
+# ---------------------------------------------------------------------------
+
+
+def test_guardrails_prompt_has_nsfw_block_rule():
+    """Guardrails prompt must explicitly block NSFW/explicit adult content.
+
+    This rule must be zero-tolerance (not subject to the lenient 5-criteria
+    test) and must appear as its own section to signal higher priority.
+    """
+    nsfw_terms = ["nsfw", "sexually explicit", "adult content", "pornographic"]
+    found = [term for term in nsfw_terms if term in PROMPT_LOWER]
+    assert len(found) >= 2, (
+        "The guardrails system prompt must contain at least two of the "
+        f"following NSFW-related terms: {nsfw_terms}. Found: {found}. "
+        "Add a zero-tolerance NSFW block section to _GUARDRAILS_SYSTEM_PROMPT."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test 7: NSFW block must be independent of the lenient 5-criteria test
+# ---------------------------------------------------------------------------
+
+
+def test_guardrails_nsfw_rule_is_zero_tolerance():
+    """NSFW block rule must NOT be inside the 'ONLY BLOCK' section.
+
+    The ONLY BLOCK section uses a lenient 'must meet ALL criteria' test.
+    NSFW content must be blocked unconditionally, so its rule must appear
+    BEFORE the ONLY BLOCK section (higher priority).
+    """
+    only_block_idx = PROMPT_LOWER.find("## only block")
+    assert only_block_idx != -1, "Prompt must have an '## ONLY BLOCK' section header"
+
+    # At least one NSFW term must appear BEFORE the ONLY BLOCK section
+    nsfw_terms = ["nsfw", "sexually explicit", "adult content", "pornographic"]
+    before_block = PROMPT_LOWER[:only_block_idx]
+    found_before = [term for term in nsfw_terms if term in before_block]
+    assert len(found_before) >= 1, (
+        "At least one NSFW-related term must appear BEFORE the '## ONLY BLOCK' "
+        "section to signal that NSFW blocking is zero-tolerance and not "
+        f"subject to the lenient 5-criteria test. Found before: {found_before}"
+    )

--- a/tests/evals/test_guardrails_scope.py
+++ b/tests/evals/test_guardrails_scope.py
@@ -13,6 +13,7 @@ import sys
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", ".."))
 
 from src.middleware.guardrails_middleware import _GUARDRAILS_SYSTEM_PROMPT
+from src.prompts.docs_agent_prompt import docs_agent_prompt
 
 # ---------------------------------------------------------------------------
 # Helper
@@ -205,4 +206,35 @@ def test_guardrails_nsfw_rule_is_zero_tolerance():
         "At least one NSFW-related term must appear BEFORE the '## ONLY BLOCK' "
         "section to signal that NSFW blocking is zero-tolerance and not "
         f"subject to the lenient 5-criteria test. Found before: {found_before}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test 8: Main agent prompt must have defense-in-depth NSFW refusal
+# ---------------------------------------------------------------------------
+
+AGENT_PROMPT_LOWER = docs_agent_prompt.lower()
+
+
+def test_agent_prompt_has_nsfw_refusal():
+    """Main agent prompt must instruct the agent to refuse NSFW content.
+
+    Even if the guardrails classifier fails open, the agent itself should
+    refuse to generate explicit content.
+    """
+    nsfw_terms = ["nsfw", "sexually explicit", "adult content"]
+    found_nsfw = [term for term in nsfw_terms if term in AGENT_PROMPT_LOWER]
+    assert len(found_nsfw) >= 1, (
+        "The docs agent prompt must contain at least one NSFW-related term "
+        f"as a defense-in-depth refusal instruction. Found: {found_nsfw}. "
+        "Add an NSFW refusal rule to the 'Important Customer Service Rules' "
+        "section of docs_agent_prompt."
+    )
+
+    refusal_terms = ["never", "refuse", "decline", "do not", "must not"]
+    found_refusal = [term for term in refusal_terms if term in AGENT_PROMPT_LOWER]
+    assert len(found_refusal) >= 1, (
+        "The docs agent prompt must contain refusal language alongside NSFW "
+        f"terms. Found refusal terms: {found_refusal}. The prompt should "
+        "instruct the agent to refuse, not just mention NSFW content."
     )


### PR DESCRIPTION
## Summary

- Adds zero-tolerance NSFW/explicit content blocking to the guardrails classifier, independent of the existing lenient off-topic filter
- Adds defense-in-depth NSFW refusal instruction to the main agent prompt
- Adds 3 new regression tests verifying NSFW rules are present and correctly positioned

## Details

**Layer 1 — Guardrails classifier** (`guardrails_middleware.py`):
- New `## ALWAYS BLOCK - Zero Tolerance` section in `_GUARDRAILS_SYSTEM_PROMPT`, positioned before the lenient `## ONLY BLOCK` section
- Covers: sexually explicit/pornographic/NSFW/adult content, requests to generate/describe/roleplay, graphic violence/gore/torture
- Explicitly independent of the "default is to allow" posture — blocks with 100% confidence
- Updated closing confidence threshold line to exempt Zero Tolerance categories

**Layer 2 — Agent prompt** (`docs_agent_prompt.py`):
- Added `**NEVER generate sexually explicit, NSFW, or adult content.**` to "Important Customer Service Rules"
- If the guardrails classifier fails open, the agent itself still refuses

**Tests** (`test_guardrails_scope.py`):
- Test 6: Verifies NSFW terms exist in the guardrails prompt
- Test 7: Verifies NSFW section appears before the lenient ONLY BLOCK section (zero-tolerance positioning)
- Test 8: Verifies agent prompt contains both NSFW terms and refusal language

## Test plan

- [x] All 8 guardrails scope tests pass (`pytest tests/evals/test_guardrails_scope.py -v`)
- [x] Existing default-allow posture is preserved for non-NSFW queries
- [x] Manual test: send an NSFW query and verify it is blocked
- [x] Manual test: send a LangChain question and verify it is allowed