### PR TITLE
fix region switching sign in bug

### DIFF
--- a/frontend/app/auth/callback/route.ts
+++ b/frontend/app/auth/callback/route.ts
@@ -4,6 +4,7 @@ import { NextResponse } from "next/server"
 import type { NextRequest } from "next/server"
 
 type AuthRegion = "us" | "eu" | "apac" | "aws"
+const SUPABASE_AUTH_STORAGE_KEY_PREFIX = "chat-langchain-supabase-auth"
 
 function isAuthRegion(value: string | null): value is AuthRegion {
   return value === "us" || value === "eu" || value === "apac" || value === "aws"
@@ -43,6 +44,10 @@ function redirectWithAuthError(origin: string, errorCode: string): NextResponse 
   return NextResponse.redirect(redirectUrl)
 }
 
+function getSupabaseAuthStorageKey(region: AuthRegion): string {
+  return `${SUPABASE_AUTH_STORAGE_KEY_PREFIX}-${region}`
+}
+
 export async function GET(request: NextRequest) {
   const requestUrl = new URL(request.url)
   const code = requestUrl.searchParams.get("code")
@@ -74,6 +79,9 @@ export async function GET(request: NextRequest) {
   try {
     const cookieStore = await cookies()
     const supabase = createServerClient(url, key, {
+      auth: {
+        storageKey: getSupabaseAuthStorageKey(region),
+      },
       cookies: {
         getAll() {
           return cookieStore.getAll()

--- a/frontend/lib/auth/AuthProvider.tsx
+++ b/frontend/lib/auth/AuthProvider.tsx
@@ -14,6 +14,7 @@ import {
   getStoredAuthRegion,
   getSupabaseClient,
   isSupabaseAuthConfigured,
+  signOutAllSupabaseClients,
   setStoredAuthRegion,
 } from "./supabase"
 
@@ -143,6 +144,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   const signIn = useCallback(
     async (provider: OAuthProvider) => {
       const client = requireClient()
+      setStoredAuthRegion(authRegion)
       const { error } = await client.auth.signInWithOAuth({
         provider,
         options: {
@@ -161,6 +163,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   const signInWithEmail = useCallback(
     async (email: string, password: string) => {
       const client = requireClient()
+      setStoredAuthRegion(authRegion)
       const { error } = await client.auth.signInWithPassword({
         email,
         password,
@@ -168,24 +171,14 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
 
       if (error) throw new Error(`Sign in failed: ${error.message}`)
     },
-    [requireClient]
+    [authRegion, requireClient]
   )
 
   const signOut = useCallback(async () => {
-    const client = getSupabaseClient(authRegion)
-    if (!client) {
-      setUser(null)
-      setSession(null)
-      return
-    }
-
-    const { error } = await client.auth.signOut()
-    if (error && error.message !== "Auth session missing!") {
-      throw new Error(`Sign out failed: ${error.message}`)
-    }
+    await signOutAllSupabaseClients()
     setUser(null)
     setSession(null)
-  }, [authRegion])
+  }, [])
 
   return (
     <AuthContext.Provider

--- a/frontend/lib/auth/supabase.ts
+++ b/frontend/lib/auth/supabase.ts
@@ -13,6 +13,7 @@ export const AUTH_REGION_LABELS: Record<AuthRegion, string> = {
 }
 
 const AUTH_REGION_STORAGE_KEY = "chat-langchain-auth-region"
+const SUPABASE_AUTH_STORAGE_KEY_PREFIX = "chat-langchain-supabase-auth"
 
 const supabaseConfigs: Record<AuthRegion, { url?: string; anonKey?: string }> = {
   us: {
@@ -67,6 +68,9 @@ export const setStoredAuthRegion = (region: AuthRegion): void => {
   window.localStorage.setItem(AUTH_REGION_STORAGE_KEY, region)
 }
 
+export const getSupabaseAuthStorageKey = (region: AuthRegion): string =>
+  `${SUPABASE_AUTH_STORAGE_KEY_PREFIX}-${region}`
+
 export const getSupabaseClient = (
   region: AuthRegion = getStoredAuthRegion()
 ): SupabaseClient | null => {
@@ -79,7 +83,25 @@ export const getSupabaseClient = (
     return null
   }
 
-  const client = createBrowserClient(config.url, config.anonKey)
+  const client = createBrowserClient(config.url, config.anonKey, {
+    auth: {
+      storageKey: getSupabaseAuthStorageKey(region),
+    },
+  })
   clients.set(region, client)
   return client
+}
+
+export async function signOutAllSupabaseClients(): Promise<void> {
+  await Promise.all(
+    getAvailableAuthRegions().map(async (region) => {
+      const client = getSupabaseClient(region)
+      if (!client) return
+
+      const { error } = await client.auth.signOut()
+      if (error && error.message !== "Auth session missing!") {
+        throw new Error(`Sign out failed for ${region}: ${error.message}`)
+      }
+    })
+  )
 }


### PR DESCRIPTION
signing into one region then signing out and attempting to sign into another region caused the first attempt to fail, subsequent attempts succeeded. Now first attempt works too by refreshing supabase auth state after sign out and keeping separate storage by region.