### PR TITLE
feat: upgrade docs agent to Gemini 3.5 Flash Lite

### DIFF
--- a/agent.py
+++ b/agent.py
@@ -54,7 +54,7 @@ agent = define_deep_agent(
     name="docs_agent",
     # Keep this literal so `mda deploy` can infer the provider package and
     # preflight GOOGLE_API_KEY.
-    model="google_genai:gemini-3.1-flash-lite",
+    model="google_genai:gemini-3.5-flash-lite",
     tools=docs_agent_tools,
     middleware=docs_agent_middleware,
     # The current public app does not have cross-thread user memory. Keep MDA

--- a/src/agent/config.py
+++ b/src/agent/config.py
@@ -29,8 +29,8 @@ logger = logging.getLogger(__name__)
 class ModelConfig:
     """Configuration for a supported chat model."""
 
-    id: str  # e.g., "google_genai:gemini-3.1-flash-lite"
-    name: str  # Display name, e.g., "Gemini 3.1 Flash Lite"
+    id: str  # e.g., "google_genai:gemini-3.5-flash-lite"
+    name: str  # Display name, e.g., "Gemini 3.5 Flash Lite"
     provider: str  # e.g., "google", "openai", "baseten"
     api_key_env: str  # Environment variable for API key
     description: str | None = None
@@ -55,9 +55,9 @@ MODELS: dict[str, ModelConfig] = {
         description="Cheapest GPT-5.4-class model for simple high-volume tasks",
     ),
     # Google
-    "gemini-3.1-flash-lite": ModelConfig(
-        id="google_genai:gemini-3.1-flash-lite",
-        name="Gemini 3.1 Flash Lite",
+    "gemini-3.5-flash-lite": ModelConfig(
+        id="google_genai:gemini-3.5-flash-lite",
+        name="Gemini 3.5 Flash Lite",
         provider="google",
         api_key_env="GOOGLE_API_KEY",
         description="Fastest, most cost-effective Gemini",
@@ -65,7 +65,7 @@ MODELS: dict[str, ModelConfig] = {
 }
 
 # Default models for different use cases
-DEFAULT_MODEL = MODELS["gemini-3.1-flash-lite"]
+DEFAULT_MODEL = MODELS["gemini-3.5-flash-lite"]
 GUARDRAILS_MODEL = MODELS["gpt-5.4-nano"]
 
 # Fallback chain (in order of preference)
@@ -112,14 +112,17 @@ def _raise_for_retryable_finish_reason(response: object) -> object:
 
 def _init_retrying_model(model: str) -> Runnable:
     return (
-        init_chat_model(model=model) | RunnableLambda(_raise_for_retryable_finish_reason)
+        init_chat_model(model=model)
+        | RunnableLambda(_raise_for_retryable_finish_reason)
     ).with_retry(stop_after_attempt=MAX_RETRIES + 1)
 
 
 def init_retry_fallback_model(model: str) -> Runnable:
     """Initialize a model runnable with the shared retry and fallback policy."""
     primary_model = _init_retrying_model(model)
-    fallback_models = [_init_retrying_model(fallback.id) for fallback in FALLBACK_MODELS]
+    fallback_models = [
+        _init_retrying_model(fallback.id) for fallback in FALLBACK_MODELS
+    ]
     return primary_model.with_fallbacks(fallback_models)
 
 

--- a/tests/unit/test_summarization_middleware_wiring.py
+++ b/tests/unit/test_summarization_middleware_wiring.py
@@ -25,7 +25,7 @@ def test_summarization_middleware_uses_retrying_fallback_model():
     summary_primary = getattr(summary_model, "runnable", None)
     summary_fallbacks = getattr(summary_model, "fallbacks", [])
 
-    assert middleware.model.model == "gemini-3.1-flash-lite"
+    assert middleware.model.model == "gemini-3.5-flash-lite"
     assert type(summary_model).__name__ == "RunnableWithFallbacks"
     assert getattr(summary_primary, "max_attempt_number") == config.MAX_RETRIES + 1
     assert len(summary_fallbacks) == len(config.FALLBACK_MODELS)


### PR DESCRIPTION
## Description
Upgrade the docs agent default Google model from Gemini 3.1 Flash Lite to Gemini 3.5 Flash Lite, keeping the managed deployment literal and shared model registry in sync. The summarization middleware test now expects the new default model.

## Test Plan
- [x] `NO_COLOR=1 python -m ruff format --check agent.py src/agent/config.py tests/unit/test_summarization_middleware_wiring.py`
- [x] `NO_COLOR=1 python -m ruff check agent.py src/agent/config.py tests/unit/test_summarization_middleware_wiring.py`
- [x] `NO_COLOR=1 GOOGLE_API_KEY=dummy OPENAI_API_KEY=dummy ANTHROPIC_API_KEY=dummy python -m pytest tests/unit/test_summarization_middleware_wiring.py`

Made by [Open SWE](https://openswe.vercel.app/agents/613ca1ea-1dd1-009d-9e97-3bf7345df1b8)