### PR TITLE
fix(analytics): identify Segment users by real Supabase auth ID

### DIFF
--- a/frontend/components/providers/segment-provider.tsx
+++ b/frontend/components/providers/segment-provider.tsx
@@ -38,13 +38,39 @@ export function SegmentProvider({ children }: { children: React.ReactNode }) {
   }, [user, loading])
 
   // Reset identity on logout so the next sign-in starts clean.
+  //
+  // We can't rely solely on identifiedUserIdRef here: it's component-local
+  // and starts out null on every reload. If a session expires or is revoked
+  // between visits, the next load resolves straight to user === null while
+  // the ref is still null too, which would skip reset() and leave Segment's
+  // own persisted identity (in localStorage) attributed to the former user.
+  // Segment's analytics.user().id() reflects that persisted identity
+  // directly, so check it in addition to the ref.
+  //
+  // analytics.user() isn't populated until the async SDK finishes loading —
+  // on the bootstrap stub it can read back no ID and we'd never re-check.
+  // Defer to analytics.ready(), and guard with a cancelled flag so a stale
+  // callback (e.g. the user signs back in before ready() fires) can't reset
+  // the identity we just set for them.
   useEffect(() => {
     if (typeof window === "undefined" || !window.analytics) return;
     if (loading || user) return
-    if (identifiedUserIdRef.current === null) return
 
-    identifiedUserIdRef.current = null
-    window.analytics.reset()
+    let cancelled = false;
+
+    window.analytics.ready(() => {
+      if (cancelled) return;
+
+      const persistedUserId = window.analytics.user?.()?.id?.();
+      if (identifiedUserIdRef.current === null && !persistedUserId) return;
+
+      identifiedUserIdRef.current = null;
+      window.analytics.reset();
+    });
+
+    return () => {
+      cancelled = true;
+    };
   }, [user, loading])
 
   // Track page views regardless of auth state.

--- a/frontend/components/providers/segment-provider.tsx
+++ b/frontend/components/providers/segment-provider.tsx
@@ -1,7 +1,6 @@
 "use client";
 
-import { useEffect } from "react";
-import { useUserId } from "@/lib/hooks/auth/use-user-id";
+import { useEffect, useRef } from "react";
 import { useAuth } from "@/lib/auth";
 
 // Declare analytics global type
@@ -14,29 +13,48 @@ declare global {
 /**
  * Segment Analytics Provider
  *
- * Leverages existing langgraph-user-id for tracking anonymous users.
+ * Identifies signed-in users by their real Supabase auth user ID (matching
+ * the pattern used in langchain-ai/help-portal), not by email or a
+ * client-generated guest ID. Anonymous visitors are left to Segment's own
+ * anonymous ID rather than being identify()'d with a fabricated ID.
  */
 export function SegmentProvider({ children }: { children: React.ReactNode }) {
-  const userId = useUserId(); // Uses existing langgraph-user-id logic
-  const { user } = useAuth();
+  const { user, loading } = useAuth();
+  const identifiedUserIdRef = useRef<string | null>(null);
 
+  // Identify the user once we have a real auth user ID.
   useEffect(() => {
-    // Wait for Segment to load and user ID to be ready
-    if (typeof window === "undefined" || !window.analytics || !userId) {
-      return;
-    }
+    if (typeof window === "undefined" || !window.analytics) return;
+    if (loading || !user) return;
+    if (identifiedUserIdRef.current === user.id) return;
 
-    window.analytics.identify(userId, {
+    identifiedUserIdRef.current = user.id;
+    window.analytics.identify(user.id, {
+      email: user.email,
+      name: user.user_metadata?.full_name,
       deployment: "public",
-      userType: user ? "authenticated" : "anonymous",
-      email: user?.email,
+      userType: "authenticated",
     });
+  }, [user, loading])
+
+  // Reset identity on logout so the next sign-in starts clean.
+  useEffect(() => {
+    if (typeof window === "undefined" || !window.analytics) return;
+    if (loading || user) return
+    if (identifiedUserIdRef.current === null) return
+
+    identifiedUserIdRef.current = null
+    window.analytics.reset()
+  }, [user, loading])
+
+  // Track page views regardless of auth state.
+  useEffect(() => {
+    if (typeof window === "undefined" || !window.analytics || loading) return;
 
     window.analytics.page({
       deployment: "public",
     });
-
-  }, [userId, user]);
+  }, [loading]);
 
   return <>{children}</>;
 }


### PR DESCRIPTION
The issue

We have a [fct__web_sessions](https://ro626.us1.dbt.com/explore/177425/projects/260884/environments/production/details/model.langsmith_analytics.fct__web_sessions) model in dbt which joins all of our web traffic together, sessionizes it, and handles identity resolution. Chat Langchain's current implementation cannot be included because we are not using best practices for user identification. User ID should only ever have a value of a ls_user_id, all other user properties should be passed in as traits.

chat-langchain's identify() call is currently keyed on useUserId(), which resolves to either the user's email (signed in) or a randomly generated localStorage guest UUID (user-${crypto.randomUUID()}), never the real Supabase auth user.id.

The proposed fix

I brought it in line with how help-portal does it in SegmentAnalyticsProvider — identify(user.id, { email, name, ... }),  using the real Supabase auth UUID as the identity and email/name only as traits, with the same dedupe-on-user.id and analytics.reset()-on-logout pattern you already have there.

I didn't have all the env vars needed to sign in through a real Supabase session locally, so I tested with a mock signed-in user (dev-only, gated behind NODE_ENV === 'development', not part of the diff) to trigger the identify call path.

Verified it locally with a real Segment write key — confirmed payload:
userId: "dev-mock-user-id"   // the auth user.id, not email
traits: { email, name, deployment, userType }