### PR TITLE
feat(analytics): fire Segment "Signed In" and "Chat Message Sent" events

### DIFF
--- a/frontend/components/chat/chat-interface.tsx
+++ b/frontend/components/chat/chat-interface.tsx
@@ -719,7 +719,7 @@ export function ChatInterface({
 
     trackEvent("Chat Message Sent", {
       threadId,
-      messageCount: messages.length + 1,
+      messageCount: messages.length + messageQueueRef.current.length + 1,
       hasAttachments: attachedFiles.length > 0,
     })
 

--- a/frontend/components/chat/chat-interface.tsx
+++ b/frontend/components/chat/chat-interface.tsx
@@ -9,6 +9,7 @@ import { truncate } from "@/lib/utils/string"
 import { useStreamHandler, useFeedback, useChatState } from "@/lib/hooks/chat"
 import { useAuth } from "@/lib/auth"
 import type { AuthRegion } from "@/lib/auth"
+import { trackEvent } from "@/components/providers/segment-provider"
 import { useFileUpload, useVoiceInput } from "@/lib/hooks/files"
 import { MessageList } from "./message-list"
 import { WelcomeScreen } from "./features/welcome-screen"
@@ -690,6 +691,11 @@ export function ChatInterface({
     if (autoSend) {
       const userMessage = createUserMessage(cappedMessage)
       setMessages((prev) => [...prev, userMessage])
+      trackEvent("Chat Message Sent", {
+        threadId,
+        messageCount: messages.length + 1,
+        hasAttachments: false,
+      })
       processMessage(cappedMessage, [], userMessage)
         .then(() => onInitialMessageSent?.())
         .catch((error) => {
@@ -700,7 +706,7 @@ export function ChatInterface({
       // Just populate input (existing behavior for ticket page, etc.)
       setLimitedInput(trimmedMessage)
     }
-  }, [initialMessage, autoSend, uiState.hasAutoSent, uiState.isLoadingThread, userId, client, setLimitedInput, uiDispatch, processMessage, onInitialMessageSent])
+  }, [initialMessage, autoSend, uiState.hasAutoSent, uiState.isLoadingThread, userId, client, setLimitedInput, uiDispatch, processMessage, onInitialMessageSent, threadId, messages])
 
   const handleSend = useCallback(async () => {
     if (!uiState.input.trim() && attachedFiles.length === 0) {
@@ -710,6 +716,12 @@ export function ChatInterface({
     if (!userId || !client) {
       return
     }
+
+    trackEvent("Chat Message Sent", {
+      threadId,
+      messageCount: messages.length + 1,
+      hasAttachments: attachedFiles.length > 0,
+    })
 
     const userMessage = createUserMessage(uiState.input)
     if (attachedFiles.length > 0) {
@@ -744,7 +756,7 @@ export function ChatInterface({
     if (messageQueueRef.current.length > 0) {
       processQueue()
     }
-  }, [uiState.input, uiState.isLoading, uiState.isRegenerating, attachedFiles, userId, client, setInput, clearFiles, processMessage, processQueue])
+  }, [uiState.input, uiState.isLoading, uiState.isRegenerating, attachedFiles, userId, client, setInput, clearFiles, processMessage, processQueue, threadId, messages])
 
   const handleStop = useCallback(async () => {
     console.log('User requested stop')

--- a/frontend/lib/auth/AuthProvider.tsx
+++ b/frontend/lib/auth/AuthProvider.tsx
@@ -5,6 +5,7 @@ import {
   useCallback,
   useContext,
   useEffect,
+  useRef,
   useState,
 } from "react"
 import type { AuthChangeEvent, Session, User } from "@supabase/supabase-js"
@@ -44,6 +45,11 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   const [loading, setLoading] = useState(true)
   const availableAuthRegions = getAvailableAuthRegions()
   const isConfigured = isSupabaseAuthConfigured(authRegion)
+  // Tracks the last known signed-in user id so we only fire the "Signed In"
+  // analytics event on an actual unauthenticated -> authenticated transition,
+  // not on every SIGNED_IN event (Supabase also emits SIGNED_IN when an
+  // existing session is re-confirmed, e.g. on tab refocus).
+  const lastTrackedUserIdRef = useRef<string | null>(null)
 
   const setAuthRegion = useCallback((region: AuthRegion) => {
     if (!isSupabaseAuthConfigured(region)) return
@@ -122,7 +128,17 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
           setUser(session?.user ?? null)
           setSession(session ?? null)
 
-          if (event === "SIGNED_IN" && session?.user) {
+          if (
+            event === "SIGNED_IN" &&
+            session?.user &&
+            lastTrackedUserIdRef.current !== session.user.id
+          ) {
+            // Only fires on an actual unauthenticated -> authenticated
+            // transition. Supabase can also emit SIGNED_IN when an existing
+            // session is simply re-confirmed (e.g. on tab refocus), which
+            // would otherwise inflate this event.
+            lastTrackedUserIdRef.current = session.user.id
+
             // Called directly on window.analytics (not the trackEvent
             // helper in segment-provider.tsx) to avoid a circular import:
             // segment-provider imports useAuth from this module.
@@ -136,6 +152,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
         }
 
         if (event === "SIGNED_OUT") {
+          lastTrackedUserIdRef.current = null
           setUser(null)
           setSession(null)
         }

--- a/frontend/lib/auth/AuthProvider.tsx
+++ b/frontend/lib/auth/AuthProvider.tsx
@@ -121,6 +121,18 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
         ) {
           setUser(session?.user ?? null)
           setSession(session ?? null)
+
+          if (event === "SIGNED_IN" && session?.user) {
+            // Called directly on window.analytics (not the trackEvent
+            // helper in segment-provider.tsx) to avoid a circular import:
+            // segment-provider imports useAuth from this module.
+            const provider = session.user.app_metadata?.provider ?? "email"
+            window.analytics?.track("Signed In", {
+              provider,
+              email: session.user.email,
+              deployment: "public",
+            })
+          }
         }
 
         if (event === "SIGNED_OUT") {


### PR DESCRIPTION
## Summary
Mirrors help-portal's Segment tracking so chat-langchain fires the same events for equivalent user actions:

- **"Signed In"** — fires from `AuthProvider`'s `onAuthStateChange` handler on `SIGNED_IN`, called directly on `window.analytics` to avoid a circular import with `segment-provider.tsx` (which imports `useAuth` from `AuthProvider`).
- **"Chat Message Sent"** — fires from `ChatInterface` for both the `?q=` auto-sent initial message and manual sends via `handleSend`.

"Chat Opened" is intentionally deferred to a follow-up PR — its semantics (mount vs. explicit action vs. threadId-diff) need more thought.

## Demo
Loom walkthrough: https://www.loom.com/share/0bc8e30db92941ad94eba490dc21c002

## Testing
Verified locally against a live Segment write key (events visible in Segment's debugger) with both the frontend dev server and a local MDA/LangGraph backend running.