### PR TITLE
fix: deduplicate sign-in analytics across tabs

### DIFF
--- a/frontend/__tests__/sign-in-tracking.test.mts
+++ b/frontend/__tests__/sign-in-tracking.test.mts
@@ -1,0 +1,126 @@
+import assert from "node:assert/strict"
+import test from "node:test"
+import {
+  claimSignInTracking,
+  getSignInFingerprint,
+  rememberSignInTracking,
+} from "../lib/auth/sign-in-tracking.ts"
+
+class MemoryStorage {
+  private readonly values = new Map<string, string>()
+
+  getItem(key: string): string | null {
+    return this.values.get(key) ?? null
+  }
+
+  setItem(key: string, value: string): void {
+    this.values.set(key, value)
+  }
+}
+
+class SerialLocks {
+  private readonly tails = new Map<string, Promise<void>>()
+
+  async request(
+    name: string,
+    callback: () => boolean | Promise<boolean>
+  ): Promise<boolean> {
+    const previous = this.tails.get(name) ?? Promise.resolve()
+    let release = () => {}
+    const current = new Promise<void>((resolve) => {
+      release = resolve
+    })
+    this.tails.set(name, previous.then(() => current))
+    await previous
+
+    try {
+      return await callback()
+    } finally {
+      release()
+    }
+  }
+}
+
+const user = {
+  id: "user-1",
+  last_sign_in_at: "2026-08-18T12:00:00.000Z",
+}
+
+test("seeds an existing session without counting a later refocus", async () => {
+  const storage = new MemoryStorage()
+
+  await rememberSignInTracking("us", user, storage)
+  assert.equal(await claimSignInTracking("us", user, storage), false)
+})
+
+test("deduplicates a genuine sign-in across refreshes without Web Locks", async () => {
+  const storage = new MemoryStorage()
+
+  assert.equal(await claimSignInTracking("us", user, storage), true)
+  assert.equal(await claimSignInTracking("us", user, storage), false)
+})
+
+test("serializes concurrent claims when Web Locks are available", async () => {
+  const storage = new MemoryStorage()
+  const locks = new SerialLocks()
+
+  const claims = await Promise.all([
+    claimSignInTracking("us", user, storage, locks),
+    claimSignInTracking("us", user, storage, locks),
+  ])
+
+  assert.deepEqual(claims.sort(), [false, true])
+})
+
+test("tracks later logins and rejects stale sessions", async () => {
+  const storage = new MemoryStorage()
+  const laterUser = {
+    ...user,
+    last_sign_in_at: "2026-08-18T13:00:00.000Z",
+  }
+
+  assert.equal(await claimSignInTracking("us", user, storage), true)
+  assert.equal(await claimSignInTracking("us", laterUser, storage), true)
+  assert.equal(await claimSignInTracking("us", user, storage), false)
+  assert.equal(await claimSignInTracking("us", laterUser, storage), false)
+})
+
+test("keeps tracking independent by region and user", async () => {
+  const storage = new MemoryStorage()
+
+  assert.equal(await claimSignInTracking("us", user, storage), true)
+  assert.equal(await claimSignInTracking("eu", user, storage), true)
+  assert.equal(
+    await claimSignInTracking("us", { ...user, id: "user-2" }, storage),
+    true
+  )
+  assert.equal(await claimSignInTracking("us", user, storage), false)
+})
+
+test("allows one in-memory event when storage is unavailable", async () => {
+  const storage = {
+    getItem(): string | null {
+      throw new Error("storage unavailable")
+    },
+    setItem(): void {
+      throw new Error("storage unavailable")
+    },
+  }
+  const originalWarn = console.warn
+  let warning = ""
+  console.warn = (message) => {
+    warning = String(message)
+  }
+
+  try {
+    assert.equal(await claimSignInTracking("us", user, storage), true)
+  } finally {
+    console.warn = originalWarn
+  }
+
+  assert.match(warning, /storage unavailable/)
+  assert.equal(
+    getSignInFingerprint("us", user),
+    "us:user-1:2026-08-18T12:00:00.000Z"
+  )
+})

--- a/frontend/app/auth/callback/route.ts
+++ b/frontend/app/auth/callback/route.ts
@@ -106,7 +106,10 @@ export async function GET(request: NextRequest) {
       return redirectWithAuthError(origin, "auth_failed")
     }
 
-    return NextResponse.redirect(origin)
+    const redirectUrl = new URL(origin)
+    redirectUrl.searchParams.set("auth_success", "1")
+    redirectUrl.searchParams.set("auth_region", region)
+    return NextResponse.redirect(redirectUrl)
   } catch (error) {
     console.error("Unexpected error in OAuth callback", {
       isError: error instanceof Error,

--- a/frontend/components/chat/chat-interface.tsx
+++ b/frontend/components/chat/chat-interface.tsx
@@ -719,7 +719,7 @@ export function ChatInterface({
 
     trackEvent("Chat Message Sent", {
       threadId,
-      messageCount: messages.length + 1,
+      messageCount: messages.length + messageQueueRef.current.length + 1,
       hasAttachments: attachedFiles.length > 0,
     })
 

--- a/frontend/components/chat/chat-interface.tsx
+++ b/frontend/components/chat/chat-interface.tsx
@@ -9,6 +9,7 @@ import { truncate } from "@/lib/utils/string"
 import { useStreamHandler, useFeedback, useChatState } from "@/lib/hooks/chat"
 import { useAuth } from "@/lib/auth"
 import type { AuthRegion } from "@/lib/auth"
+import { trackEvent } from "@/components/providers/segment-provider"
 import { useFileUpload, useVoiceInput } from "@/lib/hooks/files"
 import { MessageList } from "./message-list"
 import { WelcomeScreen } from "./features/welcome-screen"
@@ -690,6 +691,11 @@ export function ChatInterface({
     if (autoSend) {
       const userMessage = createUserMessage(cappedMessage)
       setMessages((prev) => [...prev, userMessage])
+      trackEvent("Chat Message Sent", {
+        threadId,
+        messageCount: messages.length + 1,
+        hasAttachments: false,
+      })
       processMessage(cappedMessage, [], userMessage)
         .then(() => onInitialMessageSent?.())
         .catch((error) => {
@@ -700,7 +706,7 @@ export function ChatInterface({
       // Just populate input (existing behavior for ticket page, etc.)
       setLimitedInput(trimmedMessage)
     }
-  }, [initialMessage, autoSend, uiState.hasAutoSent, uiState.isLoadingThread, userId, client, setLimitedInput, uiDispatch, processMessage, onInitialMessageSent])
+  }, [initialMessage, autoSend, uiState.hasAutoSent, uiState.isLoadingThread, userId, client, setLimitedInput, uiDispatch, processMessage, onInitialMessageSent, threadId, messages])
 
   const handleSend = useCallback(async () => {
     if (!uiState.input.trim() && attachedFiles.length === 0) {
@@ -710,6 +716,12 @@ export function ChatInterface({
     if (!userId || !client) {
       return
     }
+
+    trackEvent("Chat Message Sent", {
+      threadId,
+      messageCount: messages.length + 1,
+      hasAttachments: attachedFiles.length > 0,
+    })
 
     const userMessage = createUserMessage(uiState.input)
     if (attachedFiles.length > 0) {
@@ -744,7 +756,7 @@ export function ChatInterface({
     if (messageQueueRef.current.length > 0) {
       processQueue()
     }
-  }, [uiState.input, uiState.isLoading, uiState.isRegenerating, attachedFiles, userId, client, setInput, clearFiles, processMessage, processQueue])
+  }, [uiState.input, uiState.isLoading, uiState.isRegenerating, attachedFiles, userId, client, setInput, clearFiles, processMessage, processQueue, threadId, messages])
 
   const handleStop = useCallback(async () => {
     console.log('User requested stop')

--- a/frontend/lib/auth/AuthProvider.tsx
+++ b/frontend/lib/auth/AuthProvider.tsx
@@ -5,6 +5,7 @@ import {
   useCallback,
   useContext,
   useEffect,
+  useRef,
   useState,
 } from "react"
 import type { AuthChangeEvent, Session, User } from "@supabase/supabase-js"
@@ -44,6 +45,11 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   const [loading, setLoading] = useState(true)
   const availableAuthRegions = getAvailableAuthRegions()
   const isConfigured = isSupabaseAuthConfigured(authRegion)
+  // Tracks the last known signed-in user id so we only fire the "Signed In"
+  // analytics event on an actual unauthenticated -> authenticated transition,
+  // not on every SIGNED_IN event (Supabase also emits SIGNED_IN when an
+  // existing session is re-confirmed, e.g. on tab refocus).
+  const lastTrackedUserIdRef = useRef<string | null>(null)
 
   const setAuthRegion = useCallback((region: AuthRegion) => {
     if (!isSupabaseAuthConfigured(region)) return
@@ -122,7 +128,17 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
           setUser(session?.user ?? null)
           setSession(session ?? null)
 
-          if (event === "SIGNED_IN" && session?.user) {
+          if (
+            event === "SIGNED_IN" &&
+            session?.user &&
+            lastTrackedUserIdRef.current !== session.user.id
+          ) {
+            // Only fires on an actual unauthenticated -> authenticated
+            // transition. Supabase can also emit SIGNED_IN when an existing
+            // session is simply re-confirmed (e.g. on tab refocus), which
+            // would otherwise inflate this event.
+            lastTrackedUserIdRef.current = session.user.id
+
             // Called directly on window.analytics (not the trackEvent
             // helper in segment-provider.tsx) to avoid a circular import:
             // segment-provider imports useAuth from this module.
@@ -136,6 +152,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
         }
 
         if (event === "SIGNED_OUT") {
+          lastTrackedUserIdRef.current = null
           setUser(null)
           setSession(null)
         }

--- a/frontend/lib/auth/AuthProvider.tsx
+++ b/frontend/lib/auth/AuthProvider.tsx
@@ -14,10 +14,16 @@ import {
   getAvailableAuthRegions,
   getStoredAuthRegion,
   getSupabaseClient,
+  isAuthRegion,
   isSupabaseAuthConfigured,
   signOutAllSupabaseClients,
   setStoredAuthRegion,
 } from "./supabase"
+import {
+  claimSignInTracking,
+  getSignInFingerprint,
+  rememberSignInTracking,
+} from "./sign-in-tracking"
 
 export type OAuthProvider = "google" | "github" | "discord"
 
@@ -35,21 +41,40 @@ interface AuthContextType {
 }
 
 const AuthContext = createContext<AuthContextType | undefined>(undefined)
+const OAUTH_SUCCESS_PARAM = "auth_success"
+const OAUTH_REGION_PARAM = "auth_region"
+
+function getOAuthSignInRegion(): AuthRegion | null {
+  if (typeof window === "undefined") return null
+  const params = new URL(window.location.href).searchParams
+  if (params.get(OAUTH_SUCCESS_PARAM) !== "1") return null
+  const region = params.get(OAUTH_REGION_PARAM)
+  return isAuthRegion(region) && isSupabaseAuthConfigured(region) ? region : null
+}
+
+function hasOAuthSignInMarker(region: AuthRegion): boolean {
+  return getOAuthSignInRegion() === region
+}
+
+function consumeOAuthSignInMarker(region: AuthRegion): boolean {
+  if (!hasOAuthSignInMarker(region)) return false
+  const url = new URL(window.location.href)
+  url.searchParams.delete(OAUTH_SUCCESS_PARAM)
+  url.searchParams.delete(OAUTH_REGION_PARAM)
+  window.history.replaceState(null, "", `${url.pathname}${url.search}${url.hash}`)
+  return true
+}
 
 export function AuthProvider({ children }: { children: React.ReactNode }) {
   const [authRegion, setAuthRegionState] = useState<AuthRegion>(() =>
-    getStoredAuthRegion()
+    getOAuthSignInRegion() ?? getStoredAuthRegion()
   )
   const [user, setUser] = useState<User | null>(null)
   const [session, setSession] = useState<Session | null>(null)
   const [loading, setLoading] = useState(true)
   const availableAuthRegions = getAvailableAuthRegions()
   const isConfigured = isSupabaseAuthConfigured(authRegion)
-  // Tracks the last known signed-in user id so we only fire the "Signed In"
-  // analytics event on an actual unauthenticated -> authenticated transition,
-  // not on every SIGNED_IN event (Supabase also emits SIGNED_IN when an
-  // existing session is re-confirmed, e.g. on tab refocus).
-  const lastTrackedUserIdRef = useRef<string | null>(null)
+  const lastTrackedSignInRef = useRef<string | null>(null)
 
   const setAuthRegion = useCallback((region: AuthRegion) => {
     if (!isSupabaseAuthConfigured(region)) return
@@ -90,6 +115,13 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
         if (!cancelled) {
           setSession(session ?? null)
           setUser(session?.user ?? null)
+          if (session?.user && !hasOAuthSignInMarker(authRegion)) {
+            lastTrackedSignInRef.current = getSignInFingerprint(
+              authRegion,
+              session.user
+            )
+            void rememberSignInTracking(authRegion, session.user)
+          }
         }
       } catch {
         // Session check failed, user remains null
@@ -119,7 +151,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     const {
       data: { subscription },
     } = client.auth.onAuthStateChange(
-      (event: AuthChangeEvent, session: Session | null) => {
+      async (event: AuthChangeEvent, session: Session | null) => {
         if (
           event === "SIGNED_IN" ||
           event === "TOKEN_REFRESHED" ||
@@ -128,31 +160,32 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
           setUser(session?.user ?? null)
           setSession(session ?? null)
 
-          if (
-            event === "SIGNED_IN" &&
-            session?.user &&
-            lastTrackedUserIdRef.current !== session.user.id
-          ) {
-            // Only fires on an actual unauthenticated -> authenticated
-            // transition. Supabase can also emit SIGNED_IN when an existing
-            // session is simply re-confirmed (e.g. on tab refocus), which
-            // would otherwise inflate this event.
-            lastTrackedUserIdRef.current = session.user.id
+          if (session?.user) {
+            const fingerprint = getSignInFingerprint(authRegion, session.user)
+            const markedOAuthSignIn = (
+              event === "SIGNED_IN" || event === "INITIAL_SESSION"
+            ) && consumeOAuthSignInMarker(authRegion)
+            const shouldTrack = event === "SIGNED_IN" || markedOAuthSignIn
 
-            // Called directly on window.analytics (not the trackEvent
-            // helper in segment-provider.tsx) to avoid a circular import:
-            // segment-provider imports useAuth from this module.
-            const provider = session.user.app_metadata?.provider ?? "email"
-            window.analytics?.track("Signed In", {
-              provider,
-              email: session.user.email,
-              deployment: "public",
-            })
+            if (shouldTrack && lastTrackedSignInRef.current !== fingerprint) {
+              lastTrackedSignInRef.current = fingerprint
+              if (await claimSignInTracking(authRegion, session.user)) {
+                const provider = session.user.app_metadata?.provider ?? "email"
+                window.analytics?.track("Signed In", {
+                  provider,
+                  email: session.user.email,
+                  deployment: "public",
+                })
+              }
+            } else if (event === "INITIAL_SESSION" && !markedOAuthSignIn) {
+              lastTrackedSignInRef.current = fingerprint
+              void rememberSignInTracking(authRegion, session.user)
+            }
           }
         }
 
         if (event === "SIGNED_OUT") {
-          lastTrackedUserIdRef.current = null
+          lastTrackedSignInRef.current = null
           setUser(null)
           setSession(null)
         }

--- a/frontend/lib/auth/AuthProvider.tsx
+++ b/frontend/lib/auth/AuthProvider.tsx
@@ -121,6 +121,18 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
         ) {
           setUser(session?.user ?? null)
           setSession(session ?? null)
+
+          if (event === "SIGNED_IN" && session?.user) {
+            // Called directly on window.analytics (not the trackEvent
+            // helper in segment-provider.tsx) to avoid a circular import:
+            // segment-provider imports useAuth from this module.
+            const provider = session.user.app_metadata?.provider ?? "email"
+            window.analytics?.track("Signed In", {
+              provider,
+              email: session.user.email,
+              deployment: "public",
+            })
+          }
         }
 
         if (event === "SIGNED_OUT") {

--- a/frontend/lib/auth/sign-in-tracking.ts
+++ b/frontend/lib/auth/sign-in-tracking.ts
@@ -1,0 +1,77 @@
+import type { User } from "@supabase/supabase-js"
+import type { AuthRegion } from "./supabase"
+
+type SignInUser = Pick<User, "id" | "last_sign_in_at">
+type SignInTrackingStorage = Pick<Storage, "getItem" | "setItem">
+
+interface SignInTrackingLocks {
+  request(name: string, callback: () => boolean | Promise<boolean>): Promise<boolean>
+}
+
+const STORAGE_KEY_PREFIX = "chat-langchain:last-tracked-sign-in"
+const UNKNOWN_SIGN_IN_TIME = "unknown"
+
+export function getSignInFingerprint(
+  region: AuthRegion,
+  user: SignInUser
+): string {
+  return `${region}:${user.id}:${user.last_sign_in_at ?? UNKNOWN_SIGN_IN_TIME}`
+}
+
+function claimStoredSignIn(
+  storage: SignInTrackingStorage,
+  storageKey: string
+): boolean {
+  try {
+    if (storage.getItem(storageKey) === "1") return false
+    storage.setItem(storageKey, "1")
+    return true
+  } catch (error) {
+    console.warn("[Analytics] Sign-in deduplication storage unavailable", error)
+    return true
+  }
+}
+
+export async function claimSignInTracking(
+  region: AuthRegion,
+  user: SignInUser,
+  storage?: SignInTrackingStorage,
+  locks?: SignInTrackingLocks
+): Promise<boolean> {
+  const fingerprint = getSignInFingerprint(region, user)
+  const storageKey = `${STORAGE_KEY_PREFIX}:${encodeURIComponent(fingerprint)}`
+
+  let trackingStorage: SignInTrackingStorage
+  try {
+    trackingStorage = storage ?? window.localStorage
+  } catch (error) {
+    console.warn("[Analytics] Sign-in deduplication storage unavailable", error)
+    return true
+  }
+
+  const claim = () => claimStoredSignIn(trackingStorage, storageKey)
+  const lockManager = locks ?? (
+    typeof navigator === "undefined" || !navigator.locks
+      ? undefined
+      : {
+          request: (name, callback) => navigator.locks.request(name, callback),
+        }
+  )
+  if (!lockManager) return claim()
+
+  try {
+    return await lockManager.request(storageKey, claim)
+  } catch (error) {
+    console.warn("[Analytics] Sign-in deduplication lock unavailable", error)
+    return claim()
+  }
+}
+
+export async function rememberSignInTracking(
+  region: AuthRegion,
+  user: SignInUser,
+  storage?: SignInTrackingStorage,
+  locks?: SignInTrackingLocks
+): Promise<void> {
+  await claimSignInTracking(region, user, storage, locks)
+}

--- a/frontend/lib/auth/supabase.ts
+++ b/frontend/lib/auth/supabase.ts
@@ -69,8 +69,24 @@ export const getStoredAuthRegion = (): AuthRegion => {
 
 export const setStoredAuthRegion = (region: AuthRegion): void => {
   if (typeof window === "undefined") return
+
+  let storedRegion: AuthRegion
+  switch (region) {
+    case "eu":
+      storedRegion = "eu"
+      break
+    case "apac":
+      storedRegion = "apac"
+      break
+    case "aws":
+      storedRegion = "aws"
+      break
+    default:
+      storedRegion = "us"
+  }
+
   try {
-    window.localStorage.setItem(AUTH_REGION_STORAGE_KEY, region)
+    window.localStorage.setItem(AUTH_REGION_STORAGE_KEY, storedRegion)
   } catch (error) {
     console.warn("[Auth] Region storage unavailable", error)
   }

--- a/frontend/lib/auth/supabase.ts
+++ b/frontend/lib/auth/supabase.ts
@@ -55,9 +55,13 @@ export const getDefaultAuthRegion = (): AuthRegion => {
 export const getStoredAuthRegion = (): AuthRegion => {
   if (typeof window === "undefined") return getDefaultAuthRegion()
 
-  const storedRegion = window.localStorage.getItem(AUTH_REGION_STORAGE_KEY)
-  if (isAuthRegion(storedRegion) && isSupabaseAuthConfigured(storedRegion)) {
-    return storedRegion
+  try {
+    const storedRegion = window.localStorage.getItem(AUTH_REGION_STORAGE_KEY)
+    if (isAuthRegion(storedRegion) && isSupabaseAuthConfigured(storedRegion)) {
+      return storedRegion
+    }
+  } catch (error) {
+    console.warn("[Auth] Region storage unavailable", error)
   }
 
   return getDefaultAuthRegion()
@@ -65,7 +69,11 @@ export const getStoredAuthRegion = (): AuthRegion => {
 
 export const setStoredAuthRegion = (region: AuthRegion): void => {
   if (typeof window === "undefined") return
-  window.localStorage.setItem(AUTH_REGION_STORAGE_KEY, region)
+  try {
+    window.localStorage.setItem(AUTH_REGION_STORAGE_KEY, region)
+  } catch (error) {
+    console.warn("[Auth] Region storage unavailable", error)
+  }
 }
 
 export const getSupabaseAuthStorageKey = (region: AuthRegion): string =>
@@ -74,10 +82,14 @@ export const getSupabaseAuthStorageKey = (region: AuthRegion): string =>
 function clearSupabaseAuthStorage(): void {
   if (typeof window === "undefined") return
 
-  for (const key of Object.keys(window.localStorage)) {
-    if (key.startsWith(SUPABASE_AUTH_STORAGE_KEY_PREFIX)) {
-      window.localStorage.removeItem(key)
+  try {
+    for (const key of Object.keys(window.localStorage)) {
+      if (key.startsWith(SUPABASE_AUTH_STORAGE_KEY_PREFIX)) {
+        window.localStorage.removeItem(key)
+      }
     }
+  } catch (error) {
+    console.warn("[Auth] Session storage unavailable", error)
   }
 
   document.cookie

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,7 +8,8 @@
     "dev:remote": "next dev -p 3001",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test": "node --disable-warning=MODULE_TYPELESS_PACKAGE_JSON --experimental-strip-types --test __tests__/*.test.mts"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.10.0",


### PR DESCRIPTION
## Description
Adds persistent, concurrency-aware `Signed In` deduplication for PR 676 while preserving events when Web Locks or storage are unavailable. Existing sessions are seeded without tracking, and successful OAuth callbacks are marked so genuine redirect-based sign-ins still emit once.

This stacked PR targets PR 676's feature branch so merging it updates the existing analytics PR.

## Test Plan
- [x] `npm test` (6 focused cases)
- [x] TypeScript `--noEmit`

Made by [Open SWE](https://openswe.vercel.app/agents/7efd174d-6cd8-5d79-81bb-1c42f6d9e689)