### PR TITLE
feat: add OrcaRouter as a named gateway provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,9 @@ ANTHROPIC_API_KEY=sk-ant-your_anthropic_api_key_here
 OPENAI_API_KEY=sk-your_openai_api_key_here
 GOOGLE_API_KEY=your_google_api_key_here
 BASETEN_API_KEY=your_baseten_api_key_here
+ORCAROUTER_API_KEY=sk-orca-your_orcarouter_api_key_here
+# Optional override; defaults to https://api.orcarouter.ai/v1
+# ORCAROUTER_BASE_URL=https://api.orcarouter.ai/v1
 
 # =============================================================================
 # Pylon Knowledge Base

--- a/README.md
+++ b/README.md
@@ -62,6 +62,30 @@ cp .env.example .env
 | `PYLON_KB_ID`       | Pylon knowledge base ID for support articles                                            |
 | `USE_LOCAL_PROMPTS` | Optional. Set to `true` to use local prompt files instead of pulling Prompt Hub prompts |
 
+#### Optional: OrcaRouter Gateway Provider
+
+This project also supports running through the [OrcaRouter](https://www.orcarouter.ai)
+gateway. OrcaRouter exposes a single OpenAI-compatible endpoint
+(`https://api.orcarouter.ai/v1`) with one key, routing each request to the best
+model for the task. It also runs gateway-level, zero-trust security for AI agents
+on the same endpoint — screening every prompt/response and governing every tool
+call on a default-deny basis, with no application code changes.
+
+To use it, set your OrcaRouter key and select the `orcarouter` model:
+
+| Variable               | Description                                            |
+| ---------------------- | ------------------------------------------------------ |
+| `ORCAROUTER_API_KEY`   | OrcaRouter API key (`sk-orca-...`)                     |
+| `ORCAROUTER_BASE_URL`  | Optional. Defaults to `https://api.orcarouter.ai/v1`   |
+
+```bash
+export ORCAROUTER_API_KEY=sk-orca-your_key_here
+```
+
+OrcaRouter is registered in `src/agent/config.py` as the `orcarouter` model
+(`openai:orcarouter/auto`), which uses `init_chat_model` with the gateway
+`base_url` injected automatically — no other code changes required.
+
 ### Running Locally
 
 #### Backend

--- a/src/agent/config.py
+++ b/src/agent/config.py
@@ -3,10 +3,12 @@
 import logging
 import os
 from dataclasses import dataclass
+from typing import Any
 
 import dotenv
 from langchain.agents.middleware import ModelFallbackMiddleware
 from langchain.chat_models import init_chat_model
+from langchain_core.language_models.chat_models import BaseChatModel
 from langchain_core.runnables import Runnable, RunnableLambda
 
 from src.middleware.retry_middleware import (
@@ -62,6 +64,14 @@ MODELS: dict[str, ModelConfig] = {
         api_key_env="GOOGLE_API_KEY",
         description="Fastest, most cost-effective Gemini",
     ),
+    # OrcaRouter
+    "orcarouter": ModelConfig(
+        id="openai:orcarouter/auto",
+        name="OrcaRouter",
+        provider="orcarouter",
+        api_key_env="ORCAROUTER_API_KEY",
+        description="OrcaRouter gateway — one key, routed access to frontier and open-weight models",
+    ),
 }
 
 # Default models for different use cases
@@ -82,6 +92,7 @@ API_KEYS = [
     "OPENAI_API_KEY",
     "ANTHROPIC_API_KEY",
     "GOOGLE_API_KEY",
+    "ORCAROUTER_API_KEY",
 ]
 
 for key in API_KEYS:
@@ -90,15 +101,42 @@ for key in API_KEYS:
         logger.info(f"{key} configured")
 
 
+# OpenAI-compatible gateway endpoint for the OrcaRouter provider.
+ORCAROUTER_BASE_URL = os.getenv("ORCAROUTER_BASE_URL", "https://api.orcarouter.ai/v1")
+
+
 # =============================================================================
 # Model Initialization
 # =============================================================================
+
+# Reverse index of model id -> provider for gateway-aware init.
+_MODEL_PROVIDERS: dict[str, str] = {
+    model_config.id: model_config.provider for model_config in MODELS.values()
+}
+
+
+def init_configured_model(model: str, **kwargs: Any) -> BaseChatModel:
+    """Initialize a chat model, applying gateway defaults for OrcaRouter.
+
+    Mirrors ``init_chat_model`` but, for OrcaRouter models, injects the gateway
+    base URL (and ``ORCAROUTER_API_KEY`` when present) so requests route to
+    ``https://api.orcarouter.ai/v1`` instead of the OpenAI default endpoint.
+    """
+    if _MODEL_PROVIDERS.get(model) == "orcarouter":
+        kwargs.setdefault(
+            "base_url",
+            os.getenv("ORCAROUTER_BASE_URL", "https://api.orcarouter.ai/v1"),
+        )
+        if orca_key := os.getenv("ORCAROUTER_API_KEY"):
+            kwargs.setdefault("api_key", orca_key)
+    return init_chat_model(model=model, **kwargs)
+
 
 # Retry configuration
 MAX_RETRIES = int(os.getenv("MODEL_MAX_RETRIES", "2"))
 
 # Primary model. Public callers cannot switch this at runtime.
-default_model = init_chat_model(model=DEFAULT_MODEL.id)
+default_model = init_configured_model(DEFAULT_MODEL.id)
 logger.info(f"Default model: {DEFAULT_MODEL.name} ({DEFAULT_MODEL.id})")
 
 
@@ -112,7 +150,7 @@ def _raise_for_retryable_finish_reason(response: object) -> object:
 
 def _init_retrying_model(model: str) -> Runnable:
     return (
-        init_chat_model(model=model)
+        init_configured_model(model=model)
         | RunnableLambda(_raise_for_retryable_finish_reason)
     ).with_retry(stop_after_attempt=MAX_RETRIES + 1)
 
@@ -152,6 +190,7 @@ __all__ = [
     # Models
     "default_model",
     "init_retry_fallback_model",
+    "init_configured_model",
     "summarization_model",
     # Middleware
     "model_retry_middleware",
@@ -159,5 +198,6 @@ __all__ = [
     "model_fallback_middleware",
     # Config
     "MAX_RETRIES",
+    "ORCAROUTER_BASE_URL",
     "logger",
 ]

--- a/src/middleware/guardrails_middleware.py
+++ b/src/middleware/guardrails_middleware.py
@@ -8,7 +8,6 @@ from typing import Any, Literal
 
 import langsmith as ls
 from langchain.agents.middleware import AgentMiddleware, AgentState, hook_config
-from langchain.chat_models import init_chat_model
 from langchain_core.messages import AIMessage, HumanMessage, SystemMessage
 from langgraph.runtime import Runtime
 from langsmith import Client
@@ -110,6 +109,8 @@ class GuardrailsMiddleware(AgentMiddleware[GuardrailsState]):
     ):
         """Initialize guardrails with a primary classifier and fallback model."""
         super().__init__()
+        from src.agent.config import init_configured_model
+
         if model is None:
             from src.agent.config import DEFAULT_MODEL, GUARDRAILS_MODEL
 
@@ -120,11 +121,11 @@ class GuardrailsMiddleware(AgentMiddleware[GuardrailsState]):
 
             fallback_model = DEFAULT_MODEL.id
 
-        self.llm = init_chat_model(model=model, temperature=0)
+        self.llm = init_configured_model(model=model, temperature=0)
         self.classifier_llms = [(model, self.llm)]
         if fallback_model != model:
             self.classifier_llms.append(
-                (fallback_model, init_chat_model(model=fallback_model, temperature=0))
+                (fallback_model, init_configured_model(model=fallback_model, temperature=0))
             )
         self.block_off_topic = block_off_topic
         logger.info(

--- a/tests/unit/test_orcarouter_config.py
+++ b/tests/unit/test_orcarouter_config.py
@@ -1,0 +1,48 @@
+"""Tests for the OrcaRouter model registry entry and gateway-aware init."""
+
+from src.agent import config
+
+
+def test_orcarouter_is_a_registered_model():
+    """OrcaRouter should be a first-class model registry entry."""
+    assert "orcarouter" in config.MODELS
+    orcarouter = config.MODELS["orcarouter"]
+    assert orcarouter.provider == "orcarouter"
+    assert orcarouter.api_key_env == "ORCAROUTER_API_KEY"
+    assert orcarouter.id == "openai:orcarouter/auto"
+
+
+def test_init_configured_model_applies_gateway_defaults(monkeypatch):
+    """OrcaRouter models should route to the gateway base URL."""
+    monkeypatch.setenv("ORCAROUTER_API_KEY", "sk-orca-test-key")
+    llm = config.init_configured_model(config.MODELS["orcarouter"].id, temperature=0)
+    assert type(llm).__name__ == "ChatOpenAI"
+    assert llm.model_name == "orcarouter/auto"
+    assert llm.openai_api_base == "https://api.orcarouter.ai/v1"
+
+
+def test_init_configured_model_uses_env_base_url_override(monkeypatch):
+    """ORCAROUTER_BASE_URL should override the default gateway endpoint."""
+    monkeypatch.setenv("ORCAROUTER_API_KEY", "sk-orca-test-key")
+    monkeypatch.setenv("ORCAROUTER_BASE_URL", "https://proxy.example.com/v1")
+    llm = config.init_configured_model(config.MODELS["orcarouter"].id)
+    assert llm.openai_api_base == "https://proxy.example.com/v1"
+
+
+def test_init_configured_model_injects_gateway_key(monkeypatch):
+    """ORCAROUTER_API_KEY should be forwarded to the OpenAI-compatible client."""
+    monkeypatch.setenv("ORCAROUTER_API_KEY", "sk-orca-test-key")
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    llm = config.init_configured_model(config.MODELS["orcarouter"].id)
+    assert llm.openai_api_key.get_secret_value() == "sk-orca-test-key"
+
+
+def test_init_configured_model_does_not_affect_other_providers(monkeypatch):
+    """Non-OrcaRouter models should keep their native provider wiring."""
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-openai-test-key")
+    monkeypatch.setenv("ORCAROUTER_API_KEY", "sk-orca-test-key")
+    llm = config.init_configured_model(config.MODELS["gpt-5.4-nano"].id)
+    assert type(llm).__name__ == "ChatOpenAI"
+    assert llm.model_name == "gpt-5.4-nano"
+    assert llm.openai_api_base is None
+    assert llm.openai_api_key.get_secret_value() == "sk-openai-test-key"


### PR DESCRIPTION
## What changed

Adds [OrcaRouter](https://www.orcarouter.ai) as a named model provider for the Chat LangChain agent.

- **`src/agent/config.py`** — registers `orcarouter` in the `MODELS` registry (`openai:orcarouter/auto`) and adds `init_configured_model()`, a thin wrapper over LangChain's `init_chat_model` that injects the gateway `base_url` (`https://api.orcarouter.ai/v1`) and `ORCAROUTER_API_KEY` for OrcaRouter models. All existing providers are untouched.
- **`src/middleware/guardrails_middleware.py`** — uses `init_configured_model` so the guardrails classifier/fallback chain benefits from the same gateway-aware init.
- **`.env.example`** — documents `ORCAROUTER_API_KEY` (and optional `ORCAROUTER_BASE_URL`).
- **`tests/unit/test_orcarouter_config.py`** — 5 unit tests covering registry entry, gateway defaults, env override, key injection, and non-OrcaRouter isolation.

OrcaRouter exposes a single OpenAI-compatible endpoint with one key, routing each request to the best model for the task. It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

## How to use

```bash
export ORCAROUTER_API_KEY=sk-orca-...
# select the `orcarouter` model in src/agent/config.py
```

## Verification

- `ruff check` and `py_compile` pass on all changed files.
- 6 unit tests pass (5 new OrcaRouter + existing summarization wiring).
- Full test suite matches clean `master` (18 pre-existing environment failures — LangSmith hub auth, `pytest-asyncio`/StructuredTool sync-invoke incompatibility — are unchanged by this PR).
- Live tested against `https://api.orcarouter.ai/v1` with `orcarouter/auto`: returned `ORCA-OK`.

Disclosure: I'm an engineer on the OrcaRouter team.
