### PR TITLE
security: bump nanoid to 3.3.18

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -5098,9 +5098,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",


### PR DESCRIPTION
## Summary

Bumps the transitive `nanoid` dependency from 3.3.16 to 3.3.18 in `frontend/package-lock.json` to remediate Dependabot alert #179 / GHSA-2v37-7h3g-55p8 (CVE-2026-67213).

This is a lockfile-only update; parent packages and application code are unchanged.

## Test Plan

- [x] `npm --prefix frontend ci --ignore-scripts`
- [x] `npm --prefix frontend test`
- [x] Verified resolved `nanoid` version is 3.3.18, outside the vulnerable range `< 3.3.18`
- [x] `git diff --check`