### PR TITLE
Add langgraph.json for LangSmith Host deploy

### DIFF
--- a/langgraph.json
+++ b/langgraph.json
@@ -1,0 +1,6 @@
+{
+  "dependencies": ["."],
+  "graphs": {
+    "agent": "./agent.py:agent"
+  }
+}


### PR DESCRIPTION
## What

Add a root `langgraph.json` that exports the existing MDA `agent` from `agent.py`.

## Why

LangSmith Host GitHub deploys and Engine preview builds require this file. Current `master` is MDA-only and cannot be used as a Host parent.

## How

Point `graphs.agent` at `./agent.py:agent`. No runtime or prompt changes.

## Testing

Did not run a Host build. Config-only so Host can resolve the graph.


Made with [Cursor](https://cursor.com)