### PR TITLE
feat(analytics): attach Segment anonymous ID to LangSmith trace metadata

### DIFF
--- a/frontend/components/chat/chat-interface.tsx
+++ b/frontend/components/chat/chat-interface.tsx
@@ -9,7 +9,7 @@ import { truncate } from "@/lib/utils/string"
 import { useStreamHandler, useFeedback, useChatState } from "@/lib/hooks/chat"
 import { useAuth } from "@/lib/auth"
 import type { AuthRegion } from "@/lib/auth"
-import { trackEvent } from "@/components/providers/segment-provider"
+import { trackEvent, useAnalyticsContext } from "@/components/providers/segment-provider"
 import { useFileUpload, useVoiceInput } from "@/lib/hooks/files"
 import { MessageList } from "./message-list"
 import { WelcomeScreen } from "./features/welcome-screen"
@@ -256,6 +256,8 @@ export function ChatInterface({
   // Custom Hooks
   // ============================================================================
 
+  const { getAnonymousId } = useAnalyticsContext()
+
   const { processStream } = useStreamHandler({
     client,
     threadId,
@@ -265,6 +267,7 @@ export function ChatInterface({
     userId,
     userEmail,
     userName,
+    getSegmentAnonymousId: getAnonymousId,
     auth: langsmithAuth,
   })
 

--- a/frontend/components/providers/segment-provider.tsx
+++ b/frontend/components/providers/segment-provider.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useRef } from "react";
+import { createContext, useCallback, useContext, useEffect, useRef } from "react";
 import { useAuth } from "@/lib/auth";
 
 // Declare analytics global type
@@ -8,6 +8,24 @@ declare global {
   interface Window {
     analytics: any;
   }
+}
+
+/**
+ * Exposes a live accessor for Segment's anonymous ID rather than a cached
+ * value. The ID can be regenerated asynchronously by Segment (e.g. after
+ * reset() on logout), so callers should read it at the moment they need it
+ * instead of relying on a React-state snapshot that could go stale.
+ */
+interface AnalyticsContextValue {
+  getAnonymousId: () => string | null;
+}
+
+const AnalyticsContext = createContext<AnalyticsContextValue>({
+  getAnonymousId: () => null,
+});
+
+export function useAnalyticsContext(): AnalyticsContextValue {
+  return useContext(AnalyticsContext);
 }
 
 /**
@@ -21,6 +39,9 @@ declare global {
 export function SegmentProvider({ children }: { children: React.ReactNode }) {
   const { user, loading } = useAuth();
   const identifiedUserIdRef = useRef<string | null>(null);
+  // Tracks whether Segment's SDK has finished loading. Set once inside
+  // analytics.ready() below; never cleared, since readiness doesn't regress.
+  const isReadyRef = useRef(false);
 
   // Identify the user once we have a real auth user ID.
   useEffect(() => {
@@ -82,7 +103,43 @@ export function SegmentProvider({ children }: { children: React.ReactNode }) {
     });
   }, [loading]);
 
-  return <>{children}</>;
+  // Track when Segment's SDK has finished loading, independent of auth
+  // state, so getAnonymousId() below knows when it's safe to read from it.
+  useEffect(() => {
+    if (typeof window === "undefined" || !window.analytics) return;
+
+    let cancelled = false;
+
+    window.analytics.ready(() => {
+      if (!cancelled) isReadyRef.current = true;
+    });
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  // Live accessor rather than cached state: Segment can regenerate the
+  // anonymous ID asynchronously (e.g. after reset() on logout), so callers
+  // should read the current value at the moment they need it rather than a
+  // snapshot that could go stale.
+  const getAnonymousId = useCallback((): string | null => {
+    if (typeof window === "undefined" || !window.analytics || !isReadyRef.current) {
+      return null;
+    }
+
+    try {
+      return window.analytics.user?.()?.anonymousId?.() || null;
+    } catch {
+      return null;
+    }
+  }, []);
+
+  return (
+    <AnalyticsContext.Provider value={{ getAnonymousId }}>
+      {children}
+    </AnalyticsContext.Provider>
+  );
 }
 
 /**

--- a/frontend/lib/hooks/chat/use-stream-handler.ts
+++ b/frontend/lib/hooks/chat/use-stream-handler.ts
@@ -117,6 +117,13 @@ interface UseStreamHandlerProps {
   userId?: string | null
   userEmail?: string | null
   userName?: string | null
+  /**
+   * Live accessor for Segment's anonymous ID (from SegmentProvider), read at
+   * run-submission time rather than passed as a cached value — the ID can
+   * be regenerated asynchronously by Segment (e.g. after logout), so a
+   * snapshot taken at an earlier render could be stale.
+   */
+  getSegmentAnonymousId?: () => string | null
   auth: LangSmithAuth
 }
 
@@ -170,6 +177,7 @@ export function useStreamHandler({
   userId,
   userEmail,
   userName,
+  getSegmentAnonymousId,
   auth,
 }: UseStreamHandlerProps): UseStreamHandlerReturn {
   /**
@@ -417,11 +425,16 @@ export function useStreamHandler({
 
       const agentType = "docs_agent"
 
-      // Trace metadata for LangSmith observability
+      // Trace metadata for LangSmith observability.
+      // Read the Segment anonymous ID live, right before the run is created,
+      // rather than from a cached value — see getSegmentAnonymousId's doc
+      // comment. Omitted entirely (never a placeholder) when unavailable.
+      const segmentAnonymousId = getSegmentAnonymousId?.() ?? null
       const traceMetadata = {
         user_id: userId || "unknown",
         ...(userEmail && userEmail !== userId ? { user_email: userEmail } : {}),
         ...(userName && !userName.startsWith("User") ? { user_name: userName } : {}),
+        ...(segmentAnonymousId ? { segment_anonymous_id: segmentAnonymousId } : {}),
         source_type: "Chat-LangChain",
         graph: agentType,
       }
@@ -863,7 +876,7 @@ export function useStreamHandler({
     }
 
     return { assistantContent, runId }
-  }, [client, threadId, setMessages, fetchUsageMetadata, generateShareLink, onRunCreated, userId, userEmail, userName])
+  }, [client, threadId, setMessages, fetchUsageMetadata, generateShareLink, onRunCreated, userId, userEmail, userName, getSegmentAnonymousId])
 
   return { processStream }
 }


### PR DESCRIPTION
## Title
feat(analytics): attach Segment anonymous ID to LangSmith trace metadata

## Body

### Why

We want to connect Chat LangChain traces back to top-of-funnel activity (marketing site visits, campaign attribution, etc.) so we can join LangSmith trace data with Segment's user journey data. This is part of the GTM Engineering work on **Support Deflection & Resolution Reporting**.

Segment already assigns every visitor an `anonymousId` (and links it to their identified user ID once they sign in). By stamping that same ID onto each run's trace metadata as `segment_anonymous_id`, we get a stable join key between LangSmith and Segment — letting us trace a support/docs chat session back to the marketing touchpoints that led someone there, without relying on `user_id`/email (which is only present once someone signs in).

### What changed

- `segment-provider.tsx`: exposes a new `useAnalyticsContext()` hook with a `getAnonymousId()` live accessor (reads `window.analytics.user().anonymousId()` at call time, not a cached value, since Segment can regenerate the ID asynchronously — e.g. after `reset()` on logout).
- `chat-interface.tsx`: wires `getAnonymousId` from the new context into `useStreamHandler`.
- `use-stream-handler.ts`: reads the anonymous ID immediately before each run is created and adds it to trace metadata as `segment_anonymous_id`, omitted entirely (never a placeholder) when Segment hasn't loaded or the ID isn't available.

### Verification

Shipped to dev and confirmed the field shows up correctly on a live trace:

https://smith.langchain.com/o/ebbaf2eb-769b-4505-aca2-d11de10372a4/projects/p/609a1641-0edb-4572-bfb4-9bcae60c7e8a?timeModel=%7B%22duration%22%3A%221d%22%7D&peek=01a05da6-c488-76c0-82ec-8d570f4c86c1&peeked_trace=01a05da6-c488-76c0-82ec-8d570f4c86c1&start_time=2026-09-01T15%3A46%3A46.530751Z&peek_project=609a1641-0edb-4572-bfb4-9bcae60c7e8a&peekedConversationId=e9cd000c-6425-45d6-990c-3cec94d2a3e1&trace_id=01a05da6-c488-76c0-82ec-8d570f4c86c1&run_id=01a05da6-c488-76c0-82ec-8d570f4c86c1&scroll_to=output

Metadata attribute confirmed present on the run:

`segment_anonymous_id: 5ebd063c-284c-412c-b4e6-48fe6cb8547d`
<img width="842" height="1160" alt="Screenshot_2026-09-01_at_10_47_56 AM" src="https://github.com/user-attachments/assets/86ba58bd-f35f-44c9-94a6-879cb84edbf0" />


### Testing

- `yarn test` — 6/6 passing
- Manual local run against `.mda/build` backend + Google auth sign-in flow, confirmed `segment_anonymous_id` populates on trace metadata as shown above
