### PR TITLE
fix(docs-agent): handle block content in citation guard

### DIFF
--- a/src/middleware/citation_guard_middleware.py
+++ b/src/middleware/citation_guard_middleware.py
@@ -72,7 +72,9 @@ class CitationGuardMiddleware(AgentMiddleware):
         if not invalid_urls:
             return response
 
-        repaired_text = self._remove_footer_urls(footer_message.content, invalid_urls)
+        repaired_text = self._remove_footer_urls(
+            self._message_text(footer_message), invalid_urls
+        )
         if not self._urls_in_footer_text(repaired_text):
             retry_request = request.override(
                 messages=[*request.messages, *self._response_messages(response)],

--- a/tests/unit/test_docs_research_guard_middleware.py
+++ b/tests/unit/test_docs_research_guard_middleware.py
@@ -148,10 +148,16 @@ def test_ungrounded_footer_url_is_stripped_even_when_reachable(monkeypatch):
         return ModelResponse(
             result=[
                 AIMessage(
-                    content=(
-                        f"**Answer**\n\n**Relevant docs:**\n- [Guide]({grounded})\n"
-                        f"- [Other]({invented})"
-                    )
+                    content=[
+                        {
+                            "type": "text",
+                            "text": (
+                                f"**Answer**\n\n**Relevant docs:**\n"
+                                f"- [Guide]({grounded})\n"
+                                f"- [Other]({invented})"
+                            ),
+                        }
+                    ]
                 )
             ]
         )


### PR DESCRIPTION
## What

Prevent the citation guard from crashing on list-shaped AI message content.

## Why

Gemini can return content blocks instead of a plain string. The citation repair path passed those blocks directly to a regex, causing `TypeError: expected string or bytes-like object`.

## How

Normalize the footer message through the middleware's existing text helper before removing invalid URLs. The existing stripping test now uses block content to cover the production response shape.

## Testing

- `uv run pytest -q tests/unit/test_docs_research_guard_middleware.py`
- `uv run ruff check src/middleware/citation_guard_middleware.py tests/unit/test_docs_research_guard_middleware.py`
